### PR TITLE
feat: deferred switch mode with favicon preview

### DIFF
--- a/src/js/service-worker.js
+++ b/src/js/service-worker.js
@@ -9,15 +9,103 @@ chrome.runtime.onInstalled.addListener(injectEverywhere);
  */
 chrome.runtime.onMessage.addListener(onMessage);
 
+const previewTargets = new Map();
+
 /** @returns {Promise<{cyclicSwitchTab: bool}>} */
 async function getConfigs() {
 	return chrome.storage.sync.get(['cyclicSwitchTab'])
 }
 
 function onMessage(message, sender) {
-	const { direction, rightClick } = message;
+	const { action, direction, rightClick } = message;
+
+	if (action === 'confirm') {
+		confirmSwitch(sender.tab);
+		return;
+	}
+
 	const delta = direction === 'up' ? -1 : 1;
-	activeTab(sender.tab, delta, rightClick);
+
+	if (action === 'preview') {
+		previewTab(sender.tab, delta);
+	} else {
+		// action === 'switch' or legacy message without action field
+		activeTab(sender.tab, delta, rightClick);
+	}
+}
+
+async function confirmSwitch(fromTab) {
+	const targetId = previewTargets.get(fromTab.id);
+	if (!targetId) return;
+	previewTargets.delete(fromTab.id);
+	await restoreTabFavicon(targetId);
+	chrome.tabs.update(targetId, { active: true });
+}
+
+async function previewTab(fromTab, delta) {
+	const configs = await getConfigs();
+	const allTabs = await chrome.tabs.query({ windowId: fromTab.windowId });
+	const tabs = allTabs.filter(t => !t.hidden && (!fromTab.workspaceId || t.workspaceId === fromTab.workspaceId));
+
+	const currentPreviewId = previewTargets.get(fromTab.id);
+	const startId = currentPreviewId ?? fromTab.id;
+	const currentPos = tabs.findIndex(t => t.id === startId);
+	if (currentPos === -1) return;
+
+	let i = currentPos + delta;
+	let skipped = 0;
+	let tab = null;
+
+	while ((configs.cyclicSwitchTab || (i >= 0 && i < tabs.length)) && skipped < tabs.length) {
+		const currentTab = tabs[(i + tabs.length) % tabs.length];
+		if (await checkTabAvailable(currentTab)) {
+			tab = currentTab;
+			break;
+		}
+		i += delta;
+		skipped++;
+	}
+
+	if (tab) {
+		if (currentPreviewId && currentPreviewId !== tab.id) {
+			restoreTabFavicon(currentPreviewId);
+		}
+		previewTargets.set(fromTab.id, tab.id);
+		setTabPreviewFavicon(tab.id);
+	}
+}
+
+const PREVIEW_FAVICON = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='16' height='16' rx='4' fill='%231a73e8'/><path d='M4 8h8M9 5l3 3-3 3' stroke='white' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>";
+
+function setTabPreviewFavicon(tabId) {
+	chrome.scripting.executeScript({
+		target: { tabId },
+		func: (iconUrl) => {
+			if (!document.head) return;
+			let link = document.querySelector('link[data-tab-preview]');
+			if (!link) {
+				link = document.createElement('link');
+				link.rel = 'icon';
+				link.setAttribute('data-tab-preview', '1');
+				document.head.appendChild(link);
+			}
+			link.href = iconUrl;
+		},
+		args: [PREVIEW_FAVICON]
+	}).catch(() => {});
+}
+
+function restoreTabFavicon(tabId) {
+	return chrome.scripting.executeScript({
+		target: { tabId },
+		func: () => {
+			const link = document.querySelector('link[data-tab-preview]');
+			if (!link) return;
+			// Setting href to empty data URL before removing forces Chrome to re-evaluate the favicon
+			link.href = 'data:,';
+			requestAnimationFrame(() => link.remove());
+		}
+	}).catch(() => {});
 }
 
 async function activeTab(fromTab, delta, rightClick) {

--- a/src/main.js
+++ b/src/main.js
@@ -2,16 +2,39 @@ let isScrolling = false;
 let scrollTimer = null;
 let altEnabled = true;
 let rightClickEnabled = true;
+let deferredSwitchEnabled = false;
+let altPreviewing = false;
+let rightClickPreviewing = false;
 
-chrome.storage.sync.get(['altWheelEnabled', 'rightClickWheelEnabled'], (cfg) => {
+chrome.storage.sync.get(['altWheelEnabled', 'rightClickWheelEnabled', 'deferredSwitchEnabled'], (cfg) => {
     altEnabled = cfg.altWheelEnabled ?? true;
     rightClickEnabled = cfg.rightClickWheelEnabled ?? true;
+    deferredSwitchEnabled = cfg.deferredSwitchEnabled ?? false;
 });
 
 chrome.storage.onChanged.addListener((changes, areaName) => {
     if (areaName !== 'sync') return;
     if ('altWheelEnabled' in changes) altEnabled = changes.altWheelEnabled.newValue ?? true;
     if ('rightClickWheelEnabled' in changes) rightClickEnabled = changes.rightClickWheelEnabled.newValue ?? true;
+    if ('deferredSwitchEnabled' in changes) deferredSwitchEnabled = changes.deferredSwitchEnabled.newValue ?? false;
+});
+
+window.addEventListener('keyup', (e) => {
+    if (e.key === 'Alt' && altEnabled && deferredSwitchEnabled && altPreviewing) {
+        altPreviewing = false;
+        chrome.runtime?.sendMessage({ action: 'confirm' });
+    }
+});
+
+window.addEventListener('mouseup', (e) => {
+    if (e.button === 2 && rightClickEnabled && deferredSwitchEnabled && rightClickPreviewing) {
+        e.preventDefault();
+        rightClickPreviewing = false;
+        // Suppress the contextmenu that fires synchronously after this mouseup,
+        // before the service worker can inject into the source tab.
+        window.addEventListener('contextmenu', (ce) => ce.preventDefault(), { once: true });
+        chrome.runtime?.sendMessage({ action: 'confirm' });
+    }
 });
 
 window.addEventListener('wheel', function(e) {
@@ -24,7 +47,15 @@ window.addEventListener('wheel', function(e) {
     if (!isScrolling) {
         isScrolling = true;
         const direction = e.deltaY < 0 ? 'up' : 'down';
-        chrome.runtime?.sendMessage({ direction, rightClick: e.buttons === 2 });
+        const rightClick = e.buttons === 2;
+
+        if (deferredSwitchEnabled) {
+            if (rightClick) rightClickPreviewing = true;
+            else altPreviewing = true;
+            chrome.runtime?.sendMessage({ action: 'preview', direction });
+        } else {
+            chrome.runtime?.sendMessage({ action: 'switch', direction, rightClick });
+        }
     }
 
     clearTimeout(scrollTimer);

--- a/src/popup.html
+++ b/src/popup.html
@@ -122,6 +122,13 @@
                 <span class="option-desc">When enabled, scrolling past the last tab wraps around to the first, and vice versa.</span>
             </div>
         </label>
+        <label class="option">
+            <input type="checkbox" name="deferredSwitchEnabled" />
+            <div class="option-text">
+                <span class="option-label">Deferred switch</span>
+                <span class="option-desc">While scrolling, highlight the target tab without switching. The actual switch happens when you release the modifier (Alt or right-click).</span>
+            </div>
+        </label>
     </form>
     <script type="text/javascript" src="popup.js"></script>
 </body>


### PR DESCRIPTION
## Summary

- Adds a **Deferred switch** option in the popup (off by default)
- When enabled, Alt+scroll or right-click+scroll injects a blue arrow favicon into the target tab to signal where you'd land — without actually switching
- The real tab switch only happens when the modifier is released (Alt keyup / right mouse button mouseup)
- Restoring the original favicon on intermediate tabs uses `data:,` before removing the injected element, to force Chrome to re-evaluate its favicon cache

## Test plan

- [ ] Enable "Deferred switch" in the popup
- [ ] Alt+scroll across several tabs — check that only the target tab shows the blue arrow favicon, and intermediate tabs are restored
- [ ] Release Alt — check that the switch happens and the favicon is restored on the final tab
- [ ] Same with right-click+scroll — check that no context menu appears on release
- [ ] Disable the option — verify normal immediate switching behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)